### PR TITLE
fix: align cross icon properly on json upload input

### DIFF
--- a/src/screens/unAuthorized/importWallet/customUploadFile.js
+++ b/src/screens/unAuthorized/importWallet/customUploadFile.js
@@ -127,7 +127,7 @@ const CustomUploadFile = (props) => {
             isFilePicked
           && (
           <div onClick={() => handleClick('cancel')}>
-            <CancelIcon fontSize="small" style={{ marginTop: '-0.1rem', marginRight: '-0.3rem' }} />
+            <CancelIcon fontSize="small" style={{ marginTop: '0.2rem', marginRight: '-0.3rem' }} />
           </div>
           )
 


### PR DESCRIPTION
**What changes does this PR have?**
This change will fix the alignment issue of cross icon on upload JSON input.

**Ticket :**
https://xord.atlassian.net/browse/META-255

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - Go to Import wallet screen.
 - Select "Uplaod Json" Tab.
 - Choose a file and saw the cross icon alignment there

 