### PR TITLE
fix: remove extra password input box

### DIFF
--- a/src/screens/unAuthorized/importWallet/index.js
+++ b/src/screens/unAuthorized/importWallet/index.js
@@ -379,7 +379,6 @@ function ImportWallet() {
     <AuthWrapper>
       <Header centerText="Import Wallet" backHandler={() => console.log('goBack')} />
       <div>
-        <Input onChange={passwordChangeHandler} />
         <MainHeading {...mainHeading}>Restore your wallet : </MainHeading>
         <SubHeading textLightColor {...subHeading}>
           To restore your wallet enter your Seed phrase.


### PR DESCRIPTION
**What changes does this PR have?**
A small change that will remove the extra unnecessary password input in Import Wallet screen.

**Ticket :**
https://xord.atlassian.net/browse/META-256

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - Just go to Import wallet screen and look that the extra input is now being removed.