### PR TITLE
fixed META270 issue

### DIFF
--- a/src/screens/authorized/dashboard/assetsAndTransactions.js
+++ b/src/screens/authorized/dashboard/assetsAndTransactions.js
@@ -87,7 +87,7 @@ function AssetsAndTransactions({
     body: JSON.stringify({
       query,
     }),
-  }).then((r) => { console.log(r, 'responmseform quewf'); return r.json(); })
+  }).then((r) => r.json())
     .then((r) => handleTransaction(r))
     .catch((e) => console.log(e));
 
@@ -176,27 +176,29 @@ function AssetsAndTransactions({
         )}
         {isTab2Active && (
         // eslint-disable-next-line arrow-body-style
-          transactionData.length > 0 && transactionData.map((transaction) => {
-            const {
-              hash, operation, status, tokenName: tokenNames, amount,
-            } = transaction;
+          transactionData.length > 0 && transactionData
+            .filter((transaction) => transaction.tokenName === tokenName)
+            .map((transaction) => {
+              const {
+                hash, operation, status, tokenName: tokenNames, amount,
+              } = transaction;
 
-            const txCard = {
-              coin: tokenNames,
-              amountInUsd: tokenNames === 'WND' ? '$0' : '$0',
-              logo: logoChangeHandler(tokenNames),
-              handleClick: () => {
-                setTxDetailsModalData(transaction);
-                handleOpenTxDetailsModal();
-              },
-              operation,
-              status,
-              amount,
-            };
-            return (
-              <TxCard key={hash} {...txCard} />
-            );
-          })
+              const txCard = {
+                coin: tokenNames,
+                amountInUsd: tokenNames === 'WND' ? '$0' : '$0',
+                logo: logoChangeHandler(tokenNames),
+                handleClick: () => {
+                  setTxDetailsModalData(transaction);
+                  handleOpenTxDetailsModal();
+                },
+                operation,
+                status,
+                amount,
+              };
+              return (
+                <TxCard key={hash} {...txCard} />
+              );
+            })
         )}
       </div>
 

--- a/src/screens/authorized/multipleAccounts/index.js
+++ b/src/screens/authorized/multipleAccounts/index.js
@@ -21,6 +21,7 @@ import AccountList from './account';
 import DrivedAccountList from './drivedAccount';
 import { helpers } from '../../../utils';
 import accounts from '../../../utils/accounts';
+import { resetTransactions } from '../../../redux/slices/transactions';
 
 const { GenerateSeedPhrase } = accounts;
 
@@ -104,6 +105,7 @@ function MultipleAccounts() {
     // dispatch(setSeed(account.seed));
     dispatch(setPublicKey(pk));
     dispatch(setAccountName(name));
+    dispatch(resetTransactions());
     history.push('/');
   };
 


### PR DESCRIPTION
**What changes does this PR have?**
filtered the transaction history according to the network. For instance, if you're on rococo network, you'll see only transactions from rococo network

**Ticket :**
https://xord.atlassian.net/browse/META-270

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
1. Select a network 
2. Do some transactions on it
3. Switch networks to see relevant transactions.