### PR TITLE
Fix meta 266

### DIFF
--- a/src/components/styledComponents/index.js
+++ b/src/components/styledComponents/index.js
@@ -1,5 +1,5 @@
 /* eslint import/no-cycle: [2, { maxDepth: 1 }] */
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { colors, fonts } from '../../utils';
 
 const { primaryText, secondaryText, warningText } = colors;
@@ -192,6 +192,17 @@ export const MainText = styled.p`
   margin-top: 0px;
   margin-bottom: 3px;
   text-align: start;
+
+  ${(props) => props.balOverFlow
+    && css`
+      white-space: nowrap; 
+      overflow: hidden; 
+      text-overflow: ellipsis; 
+      width: 45px;
+    
+    `}
+
+  
 `;
 
 export const TxStatus = styled.p`

--- a/src/components/txCard/index.js
+++ b/src/components/txCard/index.js
@@ -48,7 +48,10 @@ function TxCard({
       }}
       >
         <VerticalContentDiv>
-          <MainText className={mainHeadingfontFamilyClass}>
+          <MainText
+            className={mainHeadingfontFamilyClass}
+            balOverFlow
+          >
             {`${trimBalance(amount)} ${coin}`}
           </MainText>
           <TxHorizontalContentDiv>


### PR DESCRIPTION
**What changes does this PR have?**
The transaction balance will now not overflow.

**Ticket :**
https://xord.atlassian.net/browse/META-266

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes
**Steps to reproduce:**
1.  Make some transactions with balances that have more than 4 to 5 characters to see elipsis instead of overflowing text.