### PR TITLE
fix: input address error message

### DIFF
--- a/src/screens/authorized/send/index.js
+++ b/src/screens/authorized/send/index.js
@@ -159,6 +159,7 @@ const Send = () => {
   });
 
   const accountToChangeHandler = (e) => {
+    setIsCorrect(true);
     accountDispatch({ type: 'USER_INPUT', val: e, valid: currentUser.activeAccount.publicKey });
   };
 


### PR DESCRIPTION
**What changes does this PR have?**
Now only one validation message will come at a time in input address place.

**Ticket :**
https://xord.atlassian.net/browse/META-226


**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - go to send screen
 - enter the active account address
 - then enter an invalid address and click on send button
 - then again enter the active account address