### PR TITLE
fix: now account creation through upload json works perfectly

### DIFF
--- a/src/screens/unAuthorized/importWallet/index.js
+++ b/src/screens/unAuthorized/importWallet/index.js
@@ -18,6 +18,7 @@ import {
   setIsResponseModalOpen, setLoadingForApi, setMainTextForSuccessModal,
   setResponseImage, setSubTextForSuccessModal,
 } from '../../../redux/slices/modalHandling';
+import { addAccount } from '../../../redux/slices/accounts';
 
 import {
   Option, OptionDiv, UploadFile, FileChosen, UploadFileDiv,
@@ -175,6 +176,11 @@ function ImportWallet() {
     dispatch(setAccountName(name));
     // dispatch(setWalletPassword(hashedPassword));
 
+    dispatch(addAccount({
+      accountName: name,
+      publicKey: add,
+    }));
+
     // const encryptedSeedWithAccountPassword = encrypt(currSeed, pass);
     // dispatch(setSeed(encryptedSeedWithAccountPassword));
   };
@@ -206,9 +212,9 @@ function ImportWallet() {
 
         // const res = await createAccount(pair);
         // console.log('res-------------', res);
-        saveAccountInRedux(val.json.address, val.json.meta.name, password);
+        await saveAccountInRedux(val.json.address, val.json.meta.name, password);
         dispatch(setLoadingForApi(false));
-        showSuccessModalAndNavigateToDashboard();
+        await showSuccessModalAndNavigateToDashboard();
       })
       .catch((err) => {
         console.log('now my loading setting to false', err);


### PR DESCRIPTION
**What changes does this PR have?**
This change will fix the Account import feature through upload JSON.

**Ticket :**
https://xord.atlassian.net/browse/META-275

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - try to import account from json upload method.