### PR TITLE
META-281 : password error validation correction

### DIFF
--- a/src/screens/unAuthorized/createWallet/index.js
+++ b/src/screens/unAuthorized/createWallet/index.js
@@ -79,16 +79,12 @@ function CreateWallet() {
   const validatePasswordAndConfirmPassword = () => {
     const regexRes = password.match(/^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[\\~!><@#$%?,;.^/&}{*)(_+:[}="|`'-])[a-zA-Z0-9\\.~!><@,;#$%?^}{/&*)(+:[}=|"`'\w-]{7,19}/);
 
-    if (regexRes == null) {
-      setPasswordError(passwordValidation);
+    if (password.length < 8) {
+      setPasswordError(minimumCharacterWarning);
       return false;
     }
     if (!(password === confirmPassword)) {
       setPasswordError(didnotMatchWarning);
-      return false;
-    }
-    if (password.length < 8 || confirmPassword.length < 8) {
-      setPasswordError(minimumCharacterWarning);
       return false;
     }
     if (regexRes == null) {


### PR DESCRIPTION
**What changes does this PR have?**
This change will fix the error message mishandling on create wallet screen password input.

**Ticket :**
https://xord.atlassian.net/browse/META-281

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - go to create wallet screen
 - test password input with different scenarios to check different error messages.