### PR TITLE
fix: upload file width

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "svg-url-loader": "^7.1.1",
     "ttf-loader": "^1.0.2",
     "url-loader": "^4.1.1",
-    "webpack": "^5.58.2",
+    "webpack": "^4.44.2",
     "webpack-cli": "^4.9.0",
     "webpack-extension-reloader": "^1.1.4"
   }

--- a/src/screens/unAuthorized/importWallet/styledComponents/index.js
+++ b/src/screens/unAuthorized/importWallet/styledComponents/index.js
@@ -41,7 +41,7 @@ export const UploadFile = styled.label`
   background-color: ${darkBackground1};
   color: ${primaryText};
   padding: 0.6rem 1rem;
-  width: 100%;
+  width: 254px;
   height: 14px;
   font-weight: 500;
   font-size: 14px;


### PR DESCRIPTION
What changes does this PR have?
- Upload File label width fixed

Ticket :
META-272

Is there any breaking changes?
Nope

Does this requires QA?
Yes

Steps to reproduce:

1. Open Dashboard
2. Open Main DropDown on the dashboard
3. Now click on Import Account
4. Go to the Upload JSON file
5. Check the upload file width and also check the password width
6. Now it's fixed both inputs have the same width