### PR TITLE
fix: change the export icon on drop down

### DIFF
--- a/src/screens/authorized/multipleAccounts/accountDropDown.js
+++ b/src/screens/authorized/multipleAccounts/accountDropDown.js
@@ -7,7 +7,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from '@mui/styles';
 import RemoveIcon from '../../../assets/images/icons/Remove.svg';
-import viewSeedIcon from '../../../assets/images/icons/openEye.svg';
+import exportIcon from '../../../assets/images/icons/export.svg';
 import derivedAccountIcon from '../../../assets/images/icons/deriveAccount.svg';
 import AuthModal from '../../../components/modals/authorization/index';
 import {
@@ -135,7 +135,7 @@ const AccountDropDown = ({
             >
               <ListItemIcon className="flexStart" style={{ color: '#fafafa' }}>
                 <img
-                  src={viewSeedIcon}
+                  src={exportIcon}
                   alt="lock-icon"
                   style={{ marginTop: '-0.2rem' }}
                 />

--- a/src/screens/authorized/multipleAccounts/childAccountDropDown.js
+++ b/src/screens/authorized/multipleAccounts/childAccountDropDown.js
@@ -7,7 +7,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from '@mui/styles';
 import RemoveIcon from '../../../assets/images/icons/Remove.svg';
-import viewSeedIcon from '../../../assets/images/icons/openEye.svg';
+import exportIcon from '../../../assets/images/icons/export.svg';
 import AuthModal from '../../../components/modals/authorization/index';
 import {
   setAuthScreenModal,
@@ -103,7 +103,7 @@ const ChildAccountDropDown = ({
             >
               <ListItemIcon className="flexStart" style={{ color: '#fafafa' }}>
                 <img
-                  src={viewSeedIcon}
+                  src={exportIcon}
                   alt="lock-icon"
                   style={{ marginTop: '-0.2rem' }}
                 />

--- a/src/screens/authorized/multipleAccounts/selfDerivedAccount.js
+++ b/src/screens/authorized/multipleAccounts/selfDerivedAccount.js
@@ -19,6 +19,7 @@ import {
 } from './styledComponent';
 import { fonts, helpers } from '../../../utils';
 import RemoveIcon from '../../../assets/images/icons/Remove.svg';
+import exportIcon from '../../../assets/images/icons/export.svg';
 import dropDownIcon from '../../../assets/images/icons/3Dots.svg';
 
 const { subHeadingfontFamilyClass, mainHeadingfontFamilyClass } = fonts;
@@ -89,7 +90,7 @@ const SelfDrivedAccountList = ({
                 key={Math.random()}
               >
                 <img
-                  src={RemoveIcon}
+                  src={exportIcon}
                   alt="remove-account"
                   width="16"
                   height="17"


### PR DESCRIPTION
**What changes does this PR have?**
Change the multiple account dropdown export icon

**Ticket :**
META 288

**Is there any breaking changes?**
Nope

**Does this requires QA?**
Yes

**Steps to reproduce:**
1. Goto the Multiple Account Screen
2. Open dropdown and check the export icon