### PR TITLE
feat: enable account switch on address click as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "svg-url-loader": "^7.1.1",
     "ttf-loader": "^1.0.2",
     "url-loader": "^4.1.1",
-    "webpack": "^4.44.2",
+    "webpack": "^5.58.2",
     "webpack-cli": "^4.9.0",
     "webpack-extension-reloader": "^1.1.4"
   }

--- a/src/screens/authorized/multipleAccounts/account.js
+++ b/src/screens/authorized/multipleAccounts/account.js
@@ -156,9 +156,10 @@ const AccountList = ({
       <Account marginBottom={marginBottom} marginTop={marginTop}>
         <AccountFlex>
           <AccountCircle />
-          <AccountText>
+          <AccountText
+            onClick={accountActive}
+          >
             <AccountMainText
-              onClick={accountActive}
               className={mainHeadingfontFamilyClass}
             >
               {accountName}

--- a/src/screens/authorized/multipleAccounts/drivedAccount.js
+++ b/src/screens/authorized/multipleAccounts/drivedAccount.js
@@ -107,22 +107,20 @@ const DrivedAccountList = ({
     <>
       <DrivedAccountMain>
         <Border />
-        <DrivedAccount>
+        <DrivedAccount
+          onClick={() => {
+            // eslint-disable-next-line no-shadow
+            setdrivedDropDownOpen(
+              (drivedDropDownOpen) => !drivedDropDownOpen,
+            );
+            checkDrivedDropdownOpen(drivedDropDownOpen);
+          }}
+        >
           <DrivedAccountText className={subHeadingfontFamilyClass}>
-            1 Drived Accounts
+            1 Derived Account
           </DrivedAccountText>
           <DropDownIcon>
-            <div
-              // eslint-disable-next-line no-shadow
-              onClick={() => {
-                // eslint-disable-next-line no-shadow
-                setdrivedDropDownOpen(
-                  (drivedDropDownOpen) => !drivedDropDownOpen,
-                );
-                checkDrivedDropdownOpen(drivedDropDownOpen);
-              }}
-              aria-hidden="true"
-            >
+            <div aria-hidden="true">
               {!drivedDropDownOpen ? (
                 <img src={downIcon} alt="drop-down-icon" />
               ) : (
@@ -140,9 +138,8 @@ const DrivedAccountList = ({
           <Account margin="1rem 0">
             <AccountFlex>
               <AccountCircle />
-              <AccountText>
+              <AccountText onClick={childAccountActive}>
                 <AccountMainText
-                  onClick={childAccountActive}
                   className={mainHeadingfontFamilyClass}
                 >
                   {`${childAccount.accountName}//0`}

--- a/src/screens/authorized/multipleAccounts/styledComponent/index.js
+++ b/src/screens/authorized/multipleAccounts/styledComponent/index.js
@@ -69,6 +69,7 @@ export const AccountCircle = styled.div`
 
 export const AccountText = styled.div`
   margin-left: "1rem";
+  cursor: pointer;
 `;
 
 export const AccountMainText = styled.p`
@@ -109,6 +110,7 @@ export const DrivedAccount = styled.div`
   padding: 0 27px;
   margin-top: -0.65rem;
   margin-bottom: 0.2rem;
+  cursor: pointer;
 `;
 
 export const Border = styled.div`


### PR DESCRIPTION
**What changes does this PR have?**
This change will enable the user to switch the account on address(that is shown under name on multiple accounts list screen) click as well.

**Ticket :**
https://xord.atlassian.net/browse/META-267

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - go to multiple accounts list screen
 - click on address to check account switching