### PR TITLE
fix: send tx on shibuya

### DIFF
--- a/src/screens/authorized/send/index.js
+++ b/src/screens/authorized/send/index.js
@@ -274,10 +274,10 @@ const Send = () => {
     console.log('ED of the chain', currentUser.api.api.consts.balances.existentialDeposit);
 
     const decimalPlacesForTxFee = await api.registry.chainDecimals;
-
     const info = await api.tx.balances
       .transfer(currentUser.activeAccount.publicKey,
-        amountState.value * 10 ** decimalPlacesForTxFee)
+        // eslint-disable-next-line no-undef
+        BigInt(amountState.value * 10 ** decimalPlacesForTxFee))
       .paymentInfo(accountToSate.value);
 
     console.log('After info');

--- a/src/utils/services.js
+++ b/src/utils/services.js
@@ -64,7 +64,8 @@ const getBalanceWithMultipleTokens = async (api, account) => {
 
 const getTransactionFee = async (api, sender, recipient, decimalPlaces, amount) => {
   const info = await api.tx.balances
-    .transfer(sender, amount * 10 ** decimalPlaces)
+    // eslint-disable-next-line no-undef
+    .transfer(sender, BigInt(amount * 10 ** decimalPlaces))
     .paymentInfo(recipient);
 
   return info;


### PR DESCRIPTION
**What changes does this PR have?**
Now transactions can be send on shibuya as well.

**Ticket :**
https://xord.atlassian.net/browse/META-283

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - do transaction on shibuya