### PR TITLE
subquery for context free integrated

### DIFF
--- a/src/constants/onchain.js
+++ b/src/constants/onchain.js
@@ -158,6 +158,7 @@ const BITCOUNTRY_CONFIG = {
 const CONTEXTFREE_CONFIG = {
   CHAIN_NAME: 'ContextFree',
   TOKEN_NAME: 'CTX',
+  QUERY_ENDPOINT: 'https://api.subquery.network/sq/kumailraza404/context-free-indexer',
   LOGO: contextFree,
   RPC_URL: 'wss://cf-api.ata.network',
   PREFIX: 11820,

--- a/src/utils/queryData.js
+++ b/src/utils/queryData.js
@@ -7,20 +7,9 @@ import constants from '../../src/constants/onchain';
 
 const {
   POLKADOT_CONFIG,
-  KUSAMA_CONFIG,
-  PHALA_CONFIG,
-  KHALA_CONFIG,
-  BIFROST_CONFIG,
-  MOONRIVER_CONFIG,
-  SHIDEN_CONFIG,
-  KARURA_CONFIG,
   WESTEND_CONFIG,
-  ROCOCO_CONFIG,
   DUSTY_CONFIG,
-  ACALA_MANDALA_CONFIG,
-  ASTAR_CONFIG,
-  MOONBASE_CONFIG,
-  ASGARD_CONFIG,
+  CONTEXTFREE_CONFIG,
   SHIBUYA_CONFIG,
 } = constants;
 
@@ -50,6 +39,11 @@ export const queryData = (network) =>{
             endPoint = SHIBUYA_CONFIG.QUERY_ENDPOINT;    
             return {query, endPoint};
 
+        case 'ContextFree':
+            query = getQuery(CONTEXTFREE_CONFIG.PREFIX);
+            endPoint = CONTEXTFREE_CONFIG.QUERY_ENDPOINT;    
+            return {query, endPoint};
+        
         default:
             query = getQuery(POLKADOT_CONFIG.PREFIX);
             endPoint = POLKADOT_CONFIG.QUERY_ENDPOINT; 


### PR DESCRIPTION
**What changes does this PR have?**
Integrated subquery for context free network
**Ticket :**
https://xord.atlassian.net/browse/META-293
**Is there any breaking changes?**
No
**Does this requires QA?**
Yes
**Steps to reproduce:**
1.  go to test nets and select context free network
2.  make transactions to context free network and see the transaction history