### PR TITLE
fix: remove scroll from network modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@phala/typedefs": "^0.2.29",
     "@polkadot/extension-base": "^0.42.2",
     "@polkadot/ui-keyring": "^0.85.4",
-    "@polkadot/util-crypto": "^7.4.1",
+    "@polkadot/util-crypto": "^8.3.3",
     "@polkadot/wasm-crypto-wasm": "^4.2.1",
     "@reduxjs/toolkit": "^1.6.1",
     "@testing-library/react": "^11.1.0",

--- a/src/screens/authorized/dashboard/index.js
+++ b/src/screens/authorized/dashboard/index.js
@@ -508,7 +508,6 @@ function Dashboard(props) {
             width: '300px',
             background: '#141414',
             pb: 3,
-            height: '240px',
             overflowY: 'scroll',
             overflowX: 'hidden',
             marginTop: '9rem',


### PR DESCRIPTION
**What changes does this PR have?**
unnecessary scroll removal from select network modal.

**Ticket :**
https://xord.atlassian.net/browse/META-296

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - open network modal
 - try scrolling it.