### PR TITLE
fix: cross icon size reduce on network modal

### DIFF
--- a/src/assets/images/icons/cross.svg
+++ b/src/assets/images/icons/cross.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 0.875L9.125 0L5 4.125L0.875 0L0 0.875L4.125 5L0 9.125L0.875 10L5 5.875L9.125 10L10 9.125L5.875 5L10 0.875Z" fill="#FAFAFA"/>
+</svg>

--- a/src/components/modals/selectNetwork/index.js
+++ b/src/components/modals/selectNetwork/index.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import { Modal } from '@mui/material';
 import { Box } from '@mui/system';
-import CloseIcon from '@mui/icons-material/Close';
 import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
 import { colors, fonts } from '../../../utils';
+import crossIcon from '../../../assets/images/icons/cross.svg';
 import {
   BackButton,
   CloseIconDiv,
@@ -60,7 +60,7 @@ function SelectNetwork(props) {
                 handleClose();
               }}
             >
-              <CloseIcon fontSize="small" />
+              <img src={crossIcon} alt="cross icon" />
             </CloseIconDiv>
           </TitleDiv>
 


### PR DESCRIPTION
**What changes does this PR have?**
cross icon size reduce, that is on network modal

**Ticket :**
https://xord.atlassian.net/browse/META-297

**Is there any breaking changes?**
No

**Does this requires QA?**
yes

**Steps to reproduce:**
 - open network modal and see and inspect the size of cross icon and compare it with figma. (you can find the figma snippet in jira's ticket)