### PR TITLE
fix: META-306 and META-295

### DIFF
--- a/src/components/modals/derivedAccount/index.js
+++ b/src/components/modals/derivedAccount/index.js
@@ -79,14 +79,16 @@ function DerivedAccountModal({
   // };
 
   const styledInput = {
-    placeholder: 'Enter Password',
+    placeholder: 'Enter Parent Password',
     value: password,
     className: subHeadingfontFamilyClass,
     fontSize: '9px',
     height: '20px',
     onChange: (t) => {
-      setPassword(t);
-      setPasswordError('');
+      if (t.length < 38) {
+        setPassword(t);
+        setPasswordError('');
+      }
     },
     hideHandler: () => setShowPassword(!showPassword),
     hideState: showPassword,

--- a/src/screens/unAuthorized/confirmSeed/index.js
+++ b/src/screens/unAuthorized/confirmSeed/index.js
@@ -192,7 +192,7 @@ function ConfirmSeed() {
           To confirm the mnemonic, enter the right words in the space provided below.
         </SubHeading>
       </div>
-      <SubMainWrapperForAuthScreens mb="2rem">
+      <SubMainWrapperForAuthScreens mb="18px">
         <StyledInput
           id="word-1"
           disableUnderline

--- a/src/screens/unAuthorized/welcomeBack/index.js
+++ b/src/screens/unAuthorized/welcomeBack/index.js
@@ -66,8 +66,10 @@ function WelcomeBack() {
     placeholder: 'Enter Password',
     value: password,
     onChange: (t) => {
-      setPassword(t);
-      setPasswordError('');
+      if (t.length < 40) {
+        setPassword(t);
+        setPasswordError('');
+      }
     },
     hideHandler: () => setShowPassword(!showPassword),
     hideState: showPassword,


### PR DESCRIPTION
**What changes does this PR have?**
 - Spacing issue is fixed in confirm seed screen.
 - password limit issue fix in welcome back screen and derive account modal

**Ticket :**
https://xord.atlassian.net/browse/META-295
https://xord.atlassian.net/browse/META-306

**Is there any breaking changes?**
No

**Does this requires QA?**
Yes

**Steps to reproduce:**
 - FOR META-295 : go to confirm seed screen and see the spacing between the mentioned elements in jira ticket.
 - FOR META-306 : go to welcome back screen and check password input maxlength and check same thing for derive account modal.