### PR TITLE
fix: address conversion fixed

### DIFF
--- a/src/components/modals/authorization/index.js
+++ b/src/components/modals/authorization/index.js
@@ -86,7 +86,14 @@ function AuthModal({
     width: '110px',
     height: '40px',
     fontSize: '0.8rem',
-    handleClick: handleClose,
+    handleClick: () => {
+      setPassword('');
+      handleClose();
+    },
+  };
+
+  const test = () => {
+    console.log('Running');
   };
 
   const btnS = {

--- a/src/redux/slices/activeAccount.js
+++ b/src/redux/slices/activeAccount.js
@@ -63,6 +63,9 @@ export const activeAccountSlice = createSlice({
     setJsonFileUploadScreen: (state, action) => {
       state.jsonFileUploadScreen = action.payload;
     },
+    setPrefix: (state, action) => {
+      state.prefix = action.payload;
+    },
   },
 });
 
@@ -80,6 +83,7 @@ export const {
   deleteRedux,
   setKeyringInitialized,
   setJsonFileUploadScreen,
+  setPrefix,
 } = activeAccountSlice.actions;
 
 export default activeAccountSlice.reducer;

--- a/src/screens/authorized/dashboard/index.js
+++ b/src/screens/authorized/dashboard/index.js
@@ -26,6 +26,7 @@ import {
   setPublicKey,
   resetAccountSlice,
   setJsonFileUploadScreen,
+  setPrefix
 } from '../../../redux/slices/activeAccount';
 
 import {
@@ -342,12 +343,13 @@ function Dashboard(props) {
         currentData: BetaNetworks,
       });
     } else if (rpcUrl !== data.rpcUrl) {
+      console.log('Change network ======>>>>>')
       dispatch(setApiInitializationStarts(true)); // for showing loading waves like preloader
       if (window.navigator.onLine) {
         dispatch(setLoadingForApi(true));
         dispatch(setRpcUrl({ rpcUrl: data.rpcUrl }));
         dispatch(setChainName({ chainName: data.name }));
-        // eslint-disable-next-line max-len
+        dispatch(setPrefix( data.prefix ));
         const publicKeyOfRespectiveChain = addressMapper(currentUser.activeAccount.publicKey, data.prefix);
         dispatch(setPublicKey(publicKeyOfRespectiveChain));
 

--- a/src/screens/authorized/multipleAccounts/index.js
+++ b/src/screens/authorized/multipleAccounts/index.js
@@ -22,6 +22,9 @@ import DrivedAccountList from './drivedAccount';
 import { helpers } from '../../../utils';
 import accounts from '../../../utils/accounts';
 import { resetTransactions } from '../../../redux/slices/transactions';
+import services from '../../../utils/services';
+
+const { addressMapper } = services;
 
 const { GenerateSeedPhrase } = accounts;
 
@@ -31,6 +34,7 @@ function MultipleAccounts(props) {
   const dispatch = useDispatch();
   const history = useHistory();
   const allAccounts = useSelector((state) => state.accounts);
+  const { prefix } = useSelector((state) => state.activeAccount);
 
   const [seedToPass, setSeedToPass] = useState('');
   const [derivedDropDown, setDerivedDropDown] = useState(true);
@@ -107,8 +111,10 @@ function MultipleAccounts(props) {
   }, [allAccounts]);
 
   const accountActive = (pk, name) => {
+    const publicKeyOfRespectiveChain = addressMapper(pk, prefix);
+    console.log('In multiple accounts publick key of respective chain [][][]', { pk }, publicKeyOfRespectiveChain);
     // dispatch(setSeed(account.seed));
-    dispatch(setPublicKey(pk));
+    dispatch(setPublicKey(publicKeyOfRespectiveChain));
     dispatch(setAccountName(name));
     dispatch(resetTransactions());
     history.push('/');

--- a/src/screens/unAuthorized/importWallet/index.js
+++ b/src/screens/unAuthorized/importWallet/index.js
@@ -48,6 +48,9 @@ import { fonts, colors } from '../../../utils';
 import accounts from '../../../utils/accounts';
 import ImportIcon from '../../../assets/images/modalIcons/import.svg';
 import AuthScreen from '../../../components/modals/authorization';
+import services from '../../../utils/services';
+
+const { addressMapper } = services;
 
 const { mainHeadingfontFamilyClass, subHeadingfontFamilyClass } = fonts;
 const { primaryText, darkBackground1 } = colors;
@@ -69,7 +72,7 @@ function ImportWallet() {
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const { jsonFileUploadScreen } = useSelector((state) => state.activeAccount);
+  const { jsonFileUploadScreen, prefix } = useSelector((state) => state.activeAccount);
   const params = useParams();
 
   const accounts = useSelector((state) => state.accounts);
@@ -191,9 +194,13 @@ function ImportWallet() {
 
   const saveAccountInRedux = (add, name, pass) => {
     console.log('params-------', add, name, pass);
+    const publicKeyOfRespectiveChain = addressMapper(add, prefix);
+    console.log('In multiple accounts publick key of respective chain [][][]', { pk }, publicKeyOfRespectiveChain);
+    // dispatch(setSeed(account.seed));
+    dispatch(setPublicKey(publicKeyOfRespectiveChain));
     // update redux data and tracking flags accordingly
     dispatch(setLoggedIn(true));
-    dispatch(setPublicKey(add));
+    // dispatch(setPublicKey(add));
     dispatch(setAccountName(name));
     // dispatch(setWalletPassword(hashedPassword));
 


### PR DESCRIPTION
**What changes does this PR have?**
 - Address conversion fixed. When changed to a new network the address is shown of the previous network.
 - The export account input data is not emptied

**Ticket :**
 https://xord.atlassian.net/jira/software/c/projects/META/boards/5?selectedIssue=META-309
 https://xord.atlassian.net/jira/software/c/projects/META/boards/5?selectedIssue=META-310
 
**Is there any breaking changes?**
 No

**Does this requires QA?**
 Yes
**Steps to reproduce:**
 - FOR META-309 : Open the application and change the network and now the correct address is shown of the specifc network.
  - FOR META-310 : Go to export wallet button and type in the password and close the modal. The next time the modal is opened the input field will be emptied.