### PR TITLE
fix: remove babel/polyfill warning from console

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const pkgJson = require('./package.json');
 module.exports = {
   entry: {
     popup: ['@babel/polyfill', './src/index.js'],
-    background: ['@babel/polyfill', './src/background.js'],
+    background: ['./src/background.js'],
   },
   output: {
     path: path.resolve(__dirname, 'build'),


### PR DESCRIPTION
**What changes does this PR have?**
Removed a console of babel/polyfill. the polkadot/utilcrypto error cannot be resolve from our side, for the reason look into [this](https://github.com/polkadot-js/api/issues/4315)

**Ticket :**
https://xord.atlassian.net/browse/META-308

**Is there any breaking changes?**
No

**Does this requires QA?**
No